### PR TITLE
Adding a state change to the App causes view models to be recreated

### DIFF
--- a/ReadingList/BookDetailViewModel.swift
+++ b/ReadingList/BookDetailViewModel.swift
@@ -10,6 +10,8 @@ class BookDetailViewModel: ObservableObject {
     private let readingListController: ReadingListController
 
     init(book: Book, readingListController: ReadingListController) {
+        print("BookDetailViewModel - Init")
+        
         title = book.title
         authors = book.author // TODO: Join authors
         self.book = book

--- a/ReadingList/BookListViewModel.swift
+++ b/ReadingList/BookListViewModel.swift
@@ -7,6 +7,8 @@ class BookListViewModel: ObservableObject {
     let viewForSelectedBook: (Book) -> BookDetail
 
     init(books: [Book] = [Book].dummyAllBooks, viewForSelectedBook: @escaping (Book) -> BookDetail) {
+        print("BookListViewModel - Init")
+
         self.books = books
         self.viewForSelectedBook = viewForSelectedBook
     }

--- a/ReadingList/ReadingListApp.swift
+++ b/ReadingList/ReadingListApp.swift
@@ -26,20 +26,37 @@ class RootViewModel {
 struct ReadingListApp: App {
 
     let viewModel = RootViewModel()
-
+    
+    // Let's introduce a reason to redraw, to have the `body` var called again by SwiftUI engine
+    @State var state: Bool = false
+    
     var body: some Scene {
         WindowGroup {
-            TabView {
-                NavigationView {
-                    ToReadList(viewModel: viewModel.makeToReadListViewModel())
-                        .navigationTitle("To Read 📖")
+            VStack {
+                HStack {
+                    Spacer()
+                    Button {
+                        self.state.toggle()
+                    } label: {
+                        Text("Simulate state change to cause redraw")
+                            .foregroundColor(.white)
+                    }
+                    Spacer()
                 }
-                .tabItem { Text("To Read") }
+                .background(state ? Color.blue : Color.yellow)
+                
+                TabView {
+                    NavigationView {
+                        ToReadList(viewModel: viewModel.makeToReadListViewModel())
+                            .navigationTitle("To Read 📖")
+                    }
+                    .tabItem { Text("To Read") }
 
-                NavigationView {
-                    BookList(viewModel: viewModel.makeBookListViewModel())                       .navigationTitle("Books 📚")
+                    NavigationView {
+                        BookList(viewModel: viewModel.makeBookListViewModel())                       .navigationTitle("Books 📚")
+                    }
+                    .tabItem { Text("All Books") }
                 }
-                .tabItem { Text("All Books") }
             }
         }
     }

--- a/ReadingList/ToReadListViewModel.swift
+++ b/ReadingList/ToReadListViewModel.swift
@@ -9,6 +9,8 @@ class ToReadListViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     init(readingListController: ReadingListController) {
+        print("ToReadListViewModel - Init")
+        
         self.readingListController = readingListController
 
         books = readingListController.readingList


### PR DESCRIPTION
This fake PR is just to show that if you create a ViewModel (or another object) in the `body` of a SwiftUI `View` (or in this case the `body` of an `App`), that ViewModel would be recreated whenever SwiftUI thinks your view should be updated/redrawn and the `body` var is called again.

You can see that clicking the new button, simulating a change in the App, will have SwiftUI to call your `body` again and hence create new ViewModels.

Now, this is not a real issue in your project, but you can see how it could lead to unexpected behaviours if your ViewModels had properties that hold state.